### PR TITLE
fix: remove setuptools bump to prevent pkg_resources deprecation warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN mkdir /aws && \
     cd /aws && \
     python -m venv venv && \
     . venv/bin/activate && \
-    pip install --upgrade setuptools && \
     ./scripts/installers/make-exe
 
 RUN unzip /aws/dist/awscli-exe.zip && \


### PR DESCRIPTION
The AWS CLI build process already pins setuptools==80.9.0 in its requirements-dev-lock.txt file. Upgrading setuptools to the latest version (81+) overrides this pin and causes pkg_resources deprecation warnings in the bundled executable.

The make-exe script handles all necessary dependencies including the correct setuptools version, so the explicit upgrade is unnecessary and counterproductive.

Fixes the issue reported in run 01KFMPWJHPP29WVH52XVERVRX9.