### PR TITLE
chore: bump Alpine and Python

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: ${{ github.repository }}:${{ github.sha }}
-      ALPINE_VERSION: "3.21"
+      ALPINE_VERSION: "3.23"
     steps:
       - name: Check out repository code
         uses: actions/checkout@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
       packages: write
     env:
-      ALPINE_VERSION: "3.21"
+      ALPINE_VERSION: "3.23"
     steps:
       - name: Check out repository code
         uses: actions/checkout@main

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ FROM python:3.13-alpine${ALPINE_VERSION} AS builder
 ARG AWS_CLI_VERSION
 
 RUN apk add --no-cache git \
-        unzip \
-        groff \
-        build-base \
-        libffi-dev \
-        cmake
+    unzip \
+    groff \
+    build-base \
+    libffi-dev \
+    cmake
 
 RUN mkdir /aws && \
     git clone --single-branch --depth 1 -b ${AWS_CLI_VERSION} https://github.com/aws/aws-cli.git /aws && \


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrades build/publish pipeline and image base to Alpine 3.23.
> 
> - Sets `ALPINE_VERSION` to `"3.23"` in `build.yml` and `publish.yml` to build and release against Alpine 3.23
> - `Dockerfile` continues to parameterize Alpine via `ARG ALPINE_VERSION`; minor formatting of `apk add` list, no functional Dockerfile changes beyond aligning with the new version
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4e5646c1934d3e621cb66f5026d3de09a71baa4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->