### PR TITLE
chore: bump deprecated node20 GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,16 +30,16 @@ jobs:
           tag: '2\.[0-9]+\.[0-9]+'
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         if: matrix.arch == 'arm64'
         with:
           platforms: linux/arm64
 
       - name: Setup buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build the image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/${{ matrix.arch }}
           load: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,13 +48,13 @@ jobs:
 
       - name: Set up QEMU
         if: steps.check_tag.outputs.tag_exists == 'false'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/arm64
 
       - name: Log in to GitHub registry
         if: steps.check_tag.outputs.tag_exists == 'false'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -62,18 +62,18 @@ jobs:
 
       - name: Setup buildx
         if: steps.check_tag.outputs.tag_exists == 'false'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Docker meta
         if: steps.check_tag.outputs.tag_exists == 'false'
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
 
       - name: Build the image
         if: steps.check_tag.outputs.tag_exists == 'false'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
           push: true


### PR DESCRIPTION
Bumps GitHub Actions that were using the deprecated Node.js 20 runtime.

## Changes
- `docker/build-push-action@v6 → docker/build-push-action@v7`
- `docker/login-action@v3 → docker/login-action@v4`
- `docker/metadata-action@v5 → docker/metadata-action@v6`
- `docker/setup-buildx-action@v3 → docker/setup-buildx-action@v4`
- `docker/setup-qemu-action@v3 → docker/setup-qemu-action@v4`

## Why
Node.js 20 reached EOL in April 2026 and GitHub is deprecating it on Actions runners.
See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

> ⚠️ Actions with potentially breaking changes (custom configs, major API changes) are excluded and need manual review.

🤖 Generated with Claude Code
👦🏻 Reviewed by human