### PR TITLE
ci: add Dependabot config and CODEOWNERS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      docker:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# EnterpriseReady Team - Self-hosted deployments and enterprise features
+* @spacelift-io/enterprise-ready-backend


### PR DESCRIPTION
Two related setup changes for this repo, which had neither:

- **Dependabot** for the ecosystems present here (`docker` for the Dockerfile base images and `github-actions` for the workflows), grouped per ecosystem, running **daily**. Matches the house style used across the other spacelift-io repos.
- **CODEOWNERS** assigning `@spacelift-io/enterprise-ready-backend` as the default owner, so reviews (including the Dependabot PRs) route to the team automatically.